### PR TITLE
Add aws-ec2-step-images-delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv
+test-metadata-local.yaml

--- a/steps/aws-ec2-step-images-delete/Dockerfile
+++ b/steps/aws-ec2-step-images-delete/Dockerfile
@@ -1,0 +1,9 @@
+FROM relaysh/core:latest-python
+RUN pip --no-cache-dir install boto3
+COPY "./step.py" "/step.py"
+ENTRYPOINT []
+CMD ["python3", "/step.py"]
+
+LABEL "org.opencontainers.image.title"="Delete AWS EC2 images (AMIs)"
+LABEL "org.opencontainers.image.description"="This task deletes the EC2 images (AMIs) in a given region."
+LABEL "sh.relay.sdk.version"="v1"

--- a/steps/aws-ec2-step-images-delete/README.md
+++ b/steps/aws-ec2-step-images-delete/README.md
@@ -1,5 +1,4 @@
-# aws-ec2-step-images-describe
-
+# aws-ec2-step-images-delete
 This [AWS EC2](https://aws.amazon.com/ec2/) step deletes the images (AMIs)
 corresponding to the image IDs passed in the input parameter `imageIDs`.
 

--- a/steps/aws-ec2-step-images-delete/README.md
+++ b/steps/aws-ec2-step-images-delete/README.md
@@ -1,0 +1,7 @@
+# aws-ec2-step-images-describe
+
+This [AWS EC2](https://aws.amazon.com/ec2/) step deletes the images (AMIs)
+corresponding to the image IDs passed in the input parameter `imageIDs`.
+
+If the parameter `dryRun` is set to `true`, the deletion operation will be simulated but
+the images will not be deleted.

--- a/steps/aws-ec2-step-images-delete/README.md
+++ b/steps/aws-ec2-step-images-delete/README.md
@@ -1,4 +1,5 @@
 # aws-ec2-step-images-delete
+
 This [AWS EC2](https://aws.amazon.com/ec2/) step deletes the images (AMIs)
 corresponding to the image IDs passed in the input parameter `imageIDs`.
 

--- a/steps/aws-ec2-step-images-delete/spec.schema.json
+++ b/steps/aws-ec2-step-images-delete/spec.schema.json
@@ -1,0 +1,55 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"type": "object",
+	"properties": {
+		"aws": {
+			"type": "object",
+			"description": "A mapping of AWS account configuration.",
+			"properties": {
+				"connection": {
+					"type": "object",
+					"x-relay-connectionType": "aws",
+					"description": "A Relay AWS connection to use",
+					"properties": {
+						"accessKeyID": {
+							"type": "string",
+							"description": "Access Key ID"
+						},
+						"secretAccessKey": {
+							"type": "string",
+							"description": "Secret Access Key"
+						}
+					},
+					"required": [
+						"accessKeyID",
+						"secretAccessKey"
+					]
+				},
+				"region": {
+					"type": "string",
+					"description": "The AWS region to use (for example, us-west-2)"
+				}
+			},
+			"required": [
+				"connection",
+				"region"
+			]
+		},
+		"dryRun": {
+			"type": "boolean",
+			"description": "Whether to really delete the images, default: `false`."
+		},
+		"imageIDs": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"description": "The list of EC2 image IDs identifying the images to delete."
+		}
+	},
+	"required": [
+		"aws",
+		"imageIDs"
+	],
+	"additionalProperties": false
+}

--- a/steps/aws-ec2-step-images-delete/step.py
+++ b/steps/aws-ec2-step-images-delete/step.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+import boto3
+from relay_sdk import Interface, Dynamic as D
+from botocore.exceptions import ClientError
+
+relay = Interface()
+
+session_token = None
+try:
+  session_token = relay.get(D.aws.connection.sessionToken)
+except:
+  pass
+
+sess = boto3.Session(
+    aws_access_key_id=relay.get(D.aws.connection.accessKeyID),
+    aws_secret_access_key=relay.get(D.aws.connection.secretAccessKey),
+    region_name=relay.get(D.aws.region),
+    aws_session_token=session_token
+)
+
+ec2 = sess.client('ec2')
+image_ids = relay.get(D.imageIDs)
+
+try:
+  dry_run = relay.get(D.dryRun)
+except:
+  dry_run = False
+
+print(f'Deleting the following images: {image_ids}, dryRun: {dry_run}')
+
+for image_id in image_ids:
+  try:
+    print(f'Trying to delete {image_id}... ', end='')
+    ec2.deregister_image(
+        ImageId=image_id,
+        DryRun=dry_run,
+    )
+    print(f'success.')
+
+  except ClientError as err:
+    if err.response['Error']['Code'] in ['DryRunOperation', 'InvalidAMIID.NotFound', 'InvalidAMIID.Unavailable', 'InvalidAMIID.Malformed']:
+      print(err)
+      continue
+
+    print(
+        f'Failed to perform operation on image {image_id}, stopping processing.')
+    raise(err)

--- a/steps/aws-ec2-step-images-delete/step.yaml
+++ b/steps/aws-ec2-step-images-delete/step.yaml
@@ -1,0 +1,59 @@
+# The schema version. Required. Must be exactly the string "integration/v1".
+apiVersion: integration/v1
+
+# The schema kind. Required. Must be one of "Query", "Step", or "Trigger"
+# corresponding to its directory location.
+kind: Step
+
+# The name of the action. Required. Must be exactly the name of the directory
+# containing the action.
+name: aws-ec2-step-images-delete
+
+# The version of the action. Required. Must be an integer. If specified in the
+# directory name, must be exactly the version in the directory name.
+version: 1
+
+# High-level phrase describing what this action does. Required.
+summary: Delete EC2 images
+
+# Single-paragraph explanation of what this action does in more detail.
+# Optional. Markdown.
+description: |
+  Deletes the specified images in an AWS region.
+
+# URL or path relative to this file to an icon or icons representing this
+# action. Optional. Defaults to the integration icon.
+icon:
+
+# The mechanism to use to construct this step. Required. Must be an action
+# builder. See the Builders section below.
+build:
+  # The schema version for builders. Required. For now, must be the exact
+  # string "build/v1". We may consider supporting custom third-party builders
+  # in the future.
+  apiVersion: build/v1
+
+  # The builder to use. Required.
+  kind: Docker
+
+publish:
+  repository: relaysh/aws-ec2-step-images-delete
+
+schemas:
+  spec: 
+    source: file
+    file: spec.schema.json
+
+examples:
+- summary: Delete EC2 images
+  content:
+    apiVersion: v1
+    kind: Step
+    name: delete-images
+    image: relaysh/aws-ec2-step-images-delete:dev
+    spec:
+      aws:
+        connection: ${connections.aws.'my-aws-account'}
+        region: ${parameters.awsRegion}
+      imageIDs: ['ami-0aae2505b6f1e62a3', 'ami-0cd3c226694c1fe95']
+      dryRun: true


### PR DESCRIPTION
This PR adds the `aws-ec2-step-images-delete` step which deletes AMIs specified. Closes PN-2813.