### PR TITLE
Set empty list as output if no instances are found

### DIFF
--- a/steps/aws-ec2-step-instances-describe/step.py
+++ b/steps/aws-ec2-step-instances-describe/step.py
@@ -62,6 +62,7 @@ else:
 
 instance_list = [instance for instance in raw_instances]
 if (len(instance_list) == 0):
+    relay.outputs.set('instances', list())
     print("No instances found")
     exit(0)
 


### PR DESCRIPTION
This makes it easier for downstream steps to deal with outputs.